### PR TITLE
fix(cicd): missing environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,6 @@ jobs:
       
       - name: Upload manifest to S3
         run: |
-          aws s3 cp deploy/nri-kube-events.yaml $S3_PATH/integrations/kubernetes/nri-kube-events-$RELEASE_VERSION.yaml"
-          aws s3 cp deploy/nri-kube-events.yaml $S3_PATH/integrations/kubernetes/nri-kube-events-latest.yaml"
+          aws s3 cp deploy/nri-kube-events.yaml $S3_PATH/integrations/kubernetes/nri-kube-events-$RELEASE_VERSION.yaml
+          aws s3 cp deploy/nri-kube-events.yaml $S3_PATH/integrations/kubernetes/nri-kube-events-latest.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ env:
   DOCKER_IMAGE: newrelic/nri-kube-events
   RELEASE_VERSION: ${{ github.event.release.tag_name }}
   S3_PATH: s3://nr-downloads-main/infrastructure_agent
-  PRERELEASE: ${{ github.event.release.prerelease }}
 
 jobs:
   publish:
@@ -36,16 +35,14 @@ jobs:
           password: ${{ secrets.FSI_DOCKERHUB_TOKEN }}
 
       - name: Build and push
-        env:
-          DOCKER_IMAGE_NAME: ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }}
         run: |
-          make docker-build
-          docker push $DOCKER_IMAGE_NAME
+          DOCKER_IMAGE_NAME=$DOCKER_IMAGE:$RELEASE_VERSION make docker-build
+          docker push $DOCKER_IMAGE:$RELEASE_VERSION
       - name: Tag and push latest
         if: ${{ ! github.event.release.prerelease }}
         run: |
-            docker tag $DOCKER_IMAGE_NAME $DOCKER_IMAGE:latest
-            docker push $DOCKER_IMAGE:latest
+          docker tag $DOCKER_IMAGE:$RELEASE_VERSION $DOCKER_IMAGE:latest
+          docker push $DOCKER_IMAGE:latest
         
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2
+### Changed
+- Moving pipelines to Github Actions.
+
+
 ## 1.3.0
 ### Changed
 - Update newrelic/k8s-events-forwarder to version `1.12.0`.

--- a/deploy/nri-kube-events.yaml
+++ b/deploy/nri-kube-events.yaml
@@ -61,7 +61,7 @@ spec:
     spec:
       containers:
         - name: kube-events
-          image: newrelic/nri-kube-events:1.3.0
+          image: newrelic/nri-kube-events:1.3.2
           resources:
             limits:
               memory: "128Mi"


### PR DESCRIPTION
`DOCKER_IMAGE_NAME` was missing when pushing latest version image.

I refactored the code a bit to show that the variable is used in the makefile only and it is not needed afterwards