### PR TITLE
fix(ciCD): populate automatically integration version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
           TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
-          make compile
+          make compile TAG=${TAG}
       - name: Upload artifact for docker build step
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,8 @@ jobs:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
         run: |
+          echo "${{ github.event.release.tag_name }}" | grep -E '^v[0-9.]*[0-9]$'
+          TAG=$(echo "${{ github.event.release.tag_name }}" | sed 's/^v//')
           make compile
       - name: Upload artifact for docker build step
         uses: actions/upload-artifact@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.8.0
+### Changed
+
+- Updated dependencies
+- IntegrationVersion is now automatically populated and included in the sample
+
 ## 1.7.0
 ### Changed
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,13 @@ GOOS ?=
 GOARCH ?=
 CGO_ENABLED ?= 0
 
+BUILD_DATE := $(shell date)
+TAG ?= dev
+COMMIT ?= $(shell git rev-parse HEAD || echo "unknown")
+
+LDFLAGS ?= -ldflags="-X 'main.integrationVersion=$(TAG)' -X 'main.gitCommit=$(COMMIT)' -X 'main.buildDate=$(BUILD_DATE)' "
+
+
 ifneq ($(strip $(GOOS)), )
 BUILD_TARGET := $(BUILD_TARGET)-$(GOOS)
 endif
@@ -42,7 +49,7 @@ validate:
 
 compile:
 	@echo "=== $(INTEGRATION) === [ compile ]: Building $(INTEGRATION)..."
-	CGO_ENABLED=$(CGO_ENABLED) go build -o $(BUILD_TARGET) ./cmd/nri-kube-events
+	CGO_ENABLED=$(CGO_ENABLED) go build $(LDFLAGS) -o $(BUILD_TARGET) ./cmd/nri-kube-events
 
 compile-multiarch:
 	$(MAKE) compile GOOS=linux GOARCH=amd64

--- a/cmd/nri-kube-events/main.go
+++ b/cmd/nri-kube-events/main.go
@@ -4,9 +4,12 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -26,8 +29,13 @@ import (
 )
 
 const (
-	integrationName    = "nri-kube-events"
-	integrationVersion = "1.6.0"
+	integrationName = "nri-kube-events"
+)
+
+var (
+	integrationVersion = "0.0.0"
+	gitCommit          = ""
+	buildDate          = ""
 )
 
 var (
@@ -41,10 +49,17 @@ func main() {
 	flag.Parse()
 	setLogLevel(*logLevel, logrus.InfoLevel)
 
-	logrus.Infof("Starting %s v%s", integrationName, integrationVersion)
+	logrus.Infof(
+		"New Relic %s integration Version: %s, Platform: %s, GoVersion: %s, GitCommit: %s, BuildDate: %s\n",
+		strings.Title(strings.Replace(integrationName, "com.newrelic.", "", 1)),
+		integrationVersion,
+		fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		runtime.Version(),
+		gitCommit,
+		buildDate)
 	cfg := mustLoadConfigFile(*configFile)
 
-	activeSinks, err := sinks.CreateSinks(cfg.Sinks)
+	activeSinks, err := sinks.CreateSinks(cfg.Sinks, integrationVersion)
 	if err != nil {
 		logrus.Fatalf("could not create sinks: %v", err)
 	}

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -33,14 +33,13 @@ func init() {
 }
 
 const (
-	newRelicNamespace          = "k8s"
-	newRelicCategory           = "kubernetes"
-	newRelicEventrouterVersion = "1.6.0"
-	newRelicSDKName            = "kube_events"
-	defaultAgentHTTPTimeout    = time.Second * 10
+	newRelicNamespace       = "k8s"
+	newRelicCategory        = "kubernetes"
+	newRelicSDKName         = "kube_events"
+	defaultAgentHTTPTimeout = time.Second * 10
 )
 
-func createNewRelicInfraSink(config SinkConfig) (events.Sink, error) {
+func createNewRelicInfraSink(config SinkConfig, integrationVersion string) (events.Sink, error) {
 
 	clusterName := config.MustGetString("clusterName")
 	agentEndpoint := config.MustGetString("agentEndpoint")
@@ -53,7 +52,7 @@ func createNewRelicInfraSink(config SinkConfig) (events.Sink, error) {
 		ClusterName: clusterName,
 	}
 
-	i, err := sdkIntegration.New(newRelicSDKName, newRelicEventrouterVersion, sdkIntegration.Args(&args))
+	i, err := sdkIntegration.New(newRelicSDKName, integrationVersion, sdkIntegration.Args(&args))
 	if err != nil {
 		return nil, errors.Wrap(err, "error while initializing New Relic SDK integration")
 	}
@@ -234,7 +233,9 @@ func disposeBody(response *http.Response) {
 }
 
 func (ns *newRelicInfraSink) decorateEvent(flattenedEvent map[string]interface{}) {
-	flattenedEvent["eventRouterVersion"] = newRelicEventrouterVersion
+	flattenedEvent["eventRouterVersion"] = ns.sdkIntegration.IntegrationVersion
+	flattenedEvent["integrationVersion"] = ns.sdkIntegration.IntegrationVersion
+	flattenedEvent["integrationName"] = ns.sdkIntegration.Name
 	flattenedEvent["clusterName"] = ns.clusterName
 }
 

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -117,7 +117,7 @@ func TestNewRelicSinkIntegration(t *testing.T) {
 			"agentEndpoint": testServer.URL,
 		},
 	}
-	sink, _ := createNewRelicInfraSink(config)
+	sink, _ := createNewRelicInfraSink(config, "0.0.0")
 	err = sink.HandleEvent(events.KubeEvent{
 		Verb: "ADDED",
 		Event: &v1.Event{
@@ -150,7 +150,7 @@ func TestNewRelicInfraSink_HandleEvent_AddEventError(t *testing.T) {
 			"agentEndpoint": "",
 		},
 	}
-	sink, _ := createNewRelicInfraSink(config)
+	sink, _ := createNewRelicInfraSink(config, "0.0.0")
 	err := sink.HandleEvent(events.KubeEvent{
 		Verb: "ADDED",
 		Event: &v1.Event{

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -45,7 +45,7 @@ func (s SinkConfig) GetDurationOr(name string, fallback time.Duration) time.Dura
 	return dur
 }
 
-type sinkFactory func(config SinkConfig) (events.Sink, error)
+type sinkFactory func(config SinkConfig, integrationVersion string) (events.Sink, error)
 
 // registeredSinkFactories holds all the registered sinks by this package
 var registeredSinkFactories = map[string]sinkFactory{}
@@ -60,7 +60,7 @@ func registerSink(name string, factory sinkFactory) {
 
 // CreateSinks takes a slice of SinkConfigs and attempts
 // to initialize the sinks.
-func CreateSinks(configs []SinkConfig) (map[string]events.Sink, error) {
+func CreateSinks(configs []SinkConfig, integrationVersion string) (map[string]events.Sink, error) {
 
 	sinks := make(map[string]events.Sink)
 
@@ -73,7 +73,7 @@ func CreateSinks(configs []SinkConfig) (map[string]events.Sink, error) {
 			return sinks, fmt.Errorf("sink not found: %s", sinkConf.Name)
 		}
 
-		sink, err := factory(sinkConf)
+		sink, err := factory(sinkConf, integrationVersion)
 		if err != nil {
 			return sinks, errors.Wrapf(err, "could not initialize sink %s", sinkConf.Name)
 		}

--- a/pkg/sinks/stdout.go
+++ b/pkg/sinks/stdout.go
@@ -16,7 +16,7 @@ func init() {
 	registerSink("stdout", createStdoutSink)
 }
 
-func createStdoutSink(SinkConfig) (events.Sink, error) {
+func createStdoutSink(_ SinkConfig, _ string) (events.Sink, error) {
 	return &stdoutSink{}, nil
 }
 

--- a/pkg/sinks/testdata/new_relic_infra_test_data.json
+++ b/pkg/sinks/testdata/new_relic_infra_test_data.json
@@ -1,7 +1,7 @@
 {
   "name": "kube_events",
   "protocol_version": "3",
-  "integration_version": "1.6.0",
+  "integration_version": "0.0.0",
   "data": [
     {
       "entity": {
@@ -24,7 +24,9 @@
             "event.metadata.labels.test_label2": "test_value2",
             "event.metadata.name": "test",
             "clusterName": "test-cluster",
-            "eventRouterVersion": "1.6.0",
+            "eventRouterVersion": "0.0.0",
+            "integrationName":     "kube_events",
+            "integrationVersion":  "0.0.0",
             "verb": "ADDED",
             "event.message": "The event message",
             "myCustomAttribute": "attrValue"

--- a/test/integration/test_agent_sink.go
+++ b/test/integration/test_agent_sink.go
@@ -44,7 +44,7 @@ func NewTestAgentSink() *TestAgentSink {
 		},
 	}
 
-	createdSinks, err := sinks.CreateSinks([]sinks.SinkConfig{agentSinkConfig})
+	createdSinks, err := sinks.CreateSinks([]sinks.SinkConfig{agentSinkConfig}, "0.0.0")
 	if err != nil {
 		log.Fatalf("error creating infra sink: %v", err)
 	}


### PR DESCRIPTION
The integration was populating as well a not-standard `newRelicEventrouterVersion` adding  it to the sample.

There is no use-case from my point of view to keep a different version just for that. However I kept the attribute simply populating it with integration version.

Please notice that no integrationVersion or integrationName is populated
```
      "events": [
        {
          "category": "kubernetes",
          "clusterName": "coreint-canary-gcp-standard",
          "eventRouterVersion": "1.6.0",
[...]
        },
```
 
Fix https://github.com/newrelic/nri-kube-events/issues/26