### PR TITLE
Align values.yaml with `nri-kubernetes` and use the agent helper

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart to deploy the New Relic Kube Events
 name: nri-kube-events
-version: 2.2.0
+version: 2.2.1
 appVersion: 1.8.0
 home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
 icon: https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.svg

--- a/charts/nri-kube-events/templates/_helpers.tpl
+++ b/charts/nri-kube-events/templates/_helpers.tpl
@@ -14,11 +14,15 @@
 {{- toYaml $finalSecurityContext -}}
 {{- end -}}
 
+
+
 {{- /* These are the defaults that are used for all the containers in this chart */ -}}
 {{- define "nriKubernetes.securityContext.podDefaults" -}}
 runAsUser: 1000
 runAsNonRoot: true
 {{- end -}}
+
+
 
 {{- define "nri-kube-events.securityContext.container" -}}
 {{- if include "newrelic.common.securityContext.container" . -}}
@@ -28,4 +32,14 @@ privileged: false
 allowPrivilegeEscalation: false
 readOnlyRootFilesystem: true
 {{- end -}}
+{{- end -}}
+
+
+
+{{- /*  */ -}}
+{{- define "nri-kube-events.agentConfig" -}}
+is_forward_only: true
+http_server_enabled: true
+http_server_port: 8001
+{{ include "newrelic.common.agentConfig.defaults" . }}
 {{- end -}}

--- a/charts/nri-kube-events/templates/agent-configmap.yaml
+++ b/charts/nri-kube-events/templates/agent-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.sinks.newRelicInfra -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-agent-config
+  namespace: {{ .Release.Namespace }}
+data:
+  newrelic-infra.yml: |
+    {{- include "nri-kube-events.agentConfig" . | nindent 4 }}
+{{- end }}

--- a/charts/nri-kube-events/templates/configmap.yaml
+++ b/charts/nri-kube-events/templates/configmap.yaml
@@ -1,33 +1,20 @@
 apiVersion: v1
 kind: ConfigMap
+metadata:
+  labels:
+    {{- include "newrelic.common.labels" . | nindent 4 }}
+  name: {{ include "newrelic.common.naming.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
 data:
   config.yaml: |-
     sinks:
     {{- if .Values.sinks.stdout }}
-    - name: stdout
+      - name: stdout
     {{- end }}
-    {{- if .Values.sinks.newRelicInfra}}
-    - name: newRelicInfra
-      config:
-        agentEndpoint: http://localhost:8001/v1/data
-        clusterName: {{ include "newrelic.common.cluster" . }}
-        agentHTTPTimeout: {{ .Values.agentHTTPTimeout }}
+    {{- if .Values.sinks.newRelicInfra }}
+      - name: newRelicInfra
+        config:
+          agentEndpoint: http://localhost:8001/v1/data
+          clusterName: {{ include "newrelic.common.cluster" . }}
+          agentHTTPTimeout: {{ .Values.agentHTTPTimeout }}
     {{- end }}
-metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-config
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "newrelic.common.labels" . | nindent 4 }}
-{{ if .Values.config }}
----
-apiVersion: v1
-kind: ConfigMap
-data:
-  newrelic-infra.yml: |
-{{ toYaml .Values.config | indent 4 }}
-metadata:
-  name: {{ include "newrelic.common.naming.fullname" . }}-agent-config
-  namespace: {{ .Release.Namespace }}
-  labels: 
-    {{- include "newrelic.common.labels" . | nindent 4 }}
-{{ end }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -7,23 +7,22 @@ metadata:
     {{- include "newrelic.common.labels" . | nindent 4 }}
   annotations:
   {{- if .Values.deployment.annotations }}
-{{ toYaml .Values.deployment.annotations | indent 4 }}
+    {{- toYaml .Values.deployment.annotations | nindent 4 }}
   {{- end }}
 spec:
-  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "newrelic.common.naming.name" . }}
   template:
     metadata:
-{{- if .Values.podAnnotations }}
+      {{- if .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8}}
-{{- end }}
+        {{- toYaml .Values.podAnnotations | nindent 8}}
+      {{- end }}
       labels:
         {{- include "newrelic.common.labels" . | nindent 8 }}
     spec:
-      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.image.pullSecrets) "context" .) }}
+      {{- with include "newrelic.common.images.renderPullSecrets" ( dict "pullSecrets" (list .Values.images.pullSecrets) "context" .) }}
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
@@ -33,57 +32,43 @@ spec:
       {{- end }}
       containers:
         - name: kube-events
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image.kubeEvents "context" .) }}
-          imagePullPolicy: {{ .Values.image.kubeEvents.pullPolicy }}
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.integration "context" .) }}
+          imagePullPolicy: {{ .Values.images.integration.pullPolicy }}
           {{- with include "nri-kube-events.securityContext.container" . }}
           securityContext:
             {{- . | nindent 12 }}
           {{- end }}
           {{- if .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
           args: ["-config", "/app/config/config.yaml", "-loglevel", "debug"]
           volumeMounts:
             - name: config-volume
               mountPath: /app/config
-        - name: infra-agent
-          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.image.infraAgent "context" .) }}
-          imagePullPolicy: {{ .Values.image.infraAgent.pullPolicy }}
+        {{- if .Values.sinks.newRelicInfra }}
+        - name: forwarder
+          image: {{ include "newrelic.common.images.image" ( dict "imageRoot" .Values.images.agent "context" .) }}
+          imagePullPolicy: {{ .Values.images.agent.pullPolicy }}
           {{- with include "nri-kube-events.securityContext.container" . }}
           securityContext:
             {{- . | nindent 12 }}
           {{- end }}
           ports:
-            - containerPort: 8001
+            - containerPort: {{ get (fromYaml (include "nri-kube-events.agentConfig" .)) "http_server_port" }}
           env:
             - name: NRIA_LICENSE_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "newrelic.common.license.secretName" . }}
                   key: {{ include "newrelic.common.license.secretKeyName" . }}
-            {{- if (include "newrelic.common.nrStaging" .) }}
-            - name: NRIA_STAGING
-              value: "true"
-            {{- end }}
-            {{- with include "newrelic.common.proxy" . }}
-            - name: NRIA_PROXY
-              value: {{ . | quote }}
-            {{- end }}
-            # Using FORWARD_ONLY mode to avoid the entity creation for the events.
-            - name: NRIA_IS_SECURE_FORWARD_ONLY
-              value: "false"
-            - name: NRIA_IS_FORWARD_ONLY
-              value: "true"
+
             - name: NRIA_OVERRIDE_HOSTNAME_SHORT
               valueFrom:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
-            {{- with include "newrelic.common.customAttributes" . }}
-            - name: NRIA_CUSTOM_ATTRIBUTES
-              value: {{ fromYaml . | toJson | quote }}
-            {{- end }}
+
           volumeMounts:
             - mountPath: /var/db/newrelic-infra/data
               name: tmpfs-data
@@ -91,14 +76,13 @@ spec:
               name: tmpfs-user-data
             - mountPath: /tmp
               name: tmpfs-tmp
-            {{- if .Values.config }}
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-            {{- end }}
+        {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       volumes:
-        {{- if .Values.config }}
+        {{- if .Values.sinks.newRelicInfra }}
         - name: config
           configMap:
             name: {{ include "newrelic.common.naming.fullname" . }}-agent-config

--- a/charts/nri-kube-events/tests/agent_configmap_test.yaml
+++ b/charts/nri-kube-events/tests/agent_configmap_test.yaml
@@ -1,0 +1,38 @@
+suite: test configmap for newrelic infra agent
+templates:
+  - templates/agent-configmap.yaml
+release:
+  name: my-release
+  namespace: my-namespace
+tests:
+  - it: has the correct default values
+    asserts:
+      - equal:
+          path: data.newrelic-infra\.yml
+          value: |
+            is_forward_only: true
+            http_server_enabled: true
+            http_server_port: 8001
+
+  - it: integrates properly with the common library
+    set:
+      fedramp.enabled: true
+      verboseLog: true
+    asserts:
+      - equal:
+          path: data.newrelic-infra\.yml
+          value: |
+            is_forward_only: true
+            http_server_enabled: true
+            http_server_port: 8001
+
+            verbose: 1
+            fedramp: true
+
+  - it: does not template if the http sink is disabled
+    set:
+      sinks:
+        newRelicInfra: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/nri-kube-events/tests/configmap_test.yaml
+++ b/charts/nri-kube-events/tests/configmap_test.yaml
@@ -1,4 +1,4 @@
-suite: test configmap sinks and and newrelic infra config
+suite: test configmap for sinks
 templates:
   - templates/configmap.yaml
 release:
@@ -9,17 +9,31 @@ tests:
     set:
       cluster: a-cluster
     asserts:
-      - hasDocuments:
-          count: 1
       - equal:
           path: data.config\.yaml
           value: |-
             sinks:
-            - name: newRelicInfra
-              config:
-                agentEndpoint: http://localhost:8001/v1/data
-                clusterName: a-cluster
-                agentHTTPTimeout: 30s
+              - name: newRelicInfra
+                config:
+                  agentEndpoint: http://localhost:8001/v1/data
+                  clusterName: a-cluster
+                  agentHTTPTimeout: 30s
+
+  - it: honors agentHTTPTimeout
+    set:
+      cluster: a-cluster
+      agentHTTPTimeout: 10s
+    asserts:
+      - equal:
+          path: data.config\.yaml
+          value: |-
+            sinks:
+              - name: newRelicInfra
+                config:
+                  agentEndpoint: http://localhost:8001/v1/data
+                  clusterName: a-cluster
+                  agentHTTPTimeout: 10s
+
   - it: has the correct sinks defined in local values
     set:
       cluster: a-cluster
@@ -27,34 +41,20 @@ tests:
         stdout: true
         newRelicInfra: false
     asserts:
-      - hasDocuments:
-          count: 1
       - equal:
           path: data.config\.yaml
           value: |-
             sinks:
-            - name: stdout
-        documentIndex: 0
+              - name: stdout
+
   - it: has another document generated with the proper config set
     set:
       cluster: a-cluster
       sinks:
         stdout: false
         newRelicInfra: false
-      config:
-        accountID: 111
-        region: A-REGION
     asserts:
-      - hasDocuments:
-          count: 2
       - equal:
           path: data.config\.yaml
           value: |-
             sinks:
-        documentIndex: 0
-      - equal:
-          path: data.newrelic-infra\.yml
-          value: |
-            accountID: 111
-            region: A-REGION
-        documentIndex: 1

--- a/charts/nri-kube-events/tests/deployment_test.yaml
+++ b/charts/nri-kube-events/tests/deployment_test.yaml
@@ -9,22 +9,24 @@ tests:
     set:
       cluster: my-cluster
       licenseKey: us-whatever
-      image:
+      images:
         pullSecrets:
           - name: regsecret
     asserts:
       - equal:
-          path: spec.template.spec.imagePullSecrets[0].name
-          value: regsecret
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: regsecret
+
   - it: deployment images use the proper image tag
     set:
       cluster: test-cluster
       licenseKey: us-whatever
-      image:
-        kubeEvents:
+      images:
+        integration:
           repository: newrelic/nri-kube-events
           tag: "latest"
-        infraAgent:
+        agent:
           repository: newrelic/k8s-events-forwarder
           tag: "latest"
     asserts:
@@ -34,24 +36,41 @@ tests:
       - matchRegex:
           path: spec.template.spec.containers[1].image
           pattern: .*newrelic/k8s-events-forwarder:latest$
-  - it: adds proxy when enabled
-    set:
-      cluster: test-cluster
-      proxy: "https://proxy:1234"
+
+
+  - it: by default the agent forwarder templates
     asserts:
       - contains:
-          path: spec.template.spec.containers[1].env
+          path: spec.template.spec.containers
+          any: true
           content:
-            name: NRIA_PROXY
-            value: "https://proxy:1234"
-  - it: adds customAttributes when enabled
-    set:
-      cluster: test-cluster
-      customAttributes:
-        test_tag_label: test_tag_value
-    asserts:
+            name: forwarder
       - contains:
-          path: spec.template.spec.containers[1].env
+          path: spec.template.spec.volumes
           content:
-            name: NRIA_CUSTOM_ATTRIBUTES
-            value: '{"test_tag_label":"test_tag_value"}'
+            name: config
+            configMap:
+              name: my-release-nri-kube-events-agent-config
+              items:
+                - key: newrelic-infra.yml
+                  path: newrelic-infra.yml
+
+  - it: agent does not template if the sink is disabled
+    set:
+      sinks:
+        newRelicInfra: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers
+          any: true
+          content:
+            name: forwarder
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: config
+            configMap:
+              name: my-release-nri-kube-events-agent-config
+              items:
+                - key: newrelic-infra.yml
+                  path: newrelic-infra.yml

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -36,37 +36,22 @@ sinks:
   # The newRelicInfra sink sends all events to New relic.
   newRelicInfra: true
 
-# If you wish to provide your own newrelic.yml file include it under config.
-# Note that any option configured here can be overridden by the corresponding environment variable.
-# config:
-  #
-  # New Relic Infrastructure configuration file sample
-  # https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example
-  #
-  # Lines that begin with # are comment lines and are ignored by the
-  # Infrastructure agent. If options have command line equivalents, New Relic
-  # will use the command line option to override any value set in this file.
-  #
-  # You can use this section in order to add any agent configuration.
-  # For example to add FedRAMP-compliant endpoints, to set verbose logs, to modify the agent behaviour etc
-  # verbose: 1
-
 nameOverride: ""
 
-image:
-  kubeEvents:
+images:
+  integration:
     registry:
     repository: newrelic/nri-kube-events
     tag: ""
     pullPolicy: IfNotPresent
-  infraAgent:
+  agent:
     registry:
     repository: newrelic/k8s-events-forwarder
     tag: 1.22.0
     pullPolicy: IfNotPresent
   ## It is possible to specify docker registry credentials
   ## See https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
-  # pullSecrets:
+  pullSecrets: []
   # - name: regsecret
 
 # For unprivileged mode - default is 1000.


### PR DESCRIPTION
While preparing the documentation for this chart I realized that the helper from the common library for the agent's config map was not being used.

So I raised a couple of inconsistencies with the other reference chart (`nri-kubernetes`) and added a couple of tests.