### PR TITLE
fix(chart): newline cause issues for old helm versions

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/master/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.2.3
+version: 2.2.4
 appVersion: 1.8.0
 
 dependencies:

--- a/charts/nri-kube-events/README.md
+++ b/charts/nri-kube-events/README.md
@@ -1,6 +1,6 @@
 # nri-kube-events
 
-![Version: 2.2.3](https://img.shields.io/badge/Version-2.2.3-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 2.2.4](https://img.shields.io/badge/Version-2.2.4-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kube Events router
 

--- a/charts/nri-kube-events/templates/_helpers_compatibility.tpl
+++ b/charts/nri-kube-events/templates/_helpers_compatibility.tpl
@@ -228,8 +228,7 @@ Returns a merged list of pull secrets ready to be used
 {{- $oldAgentTag := include "nri-kube-events.compatibility.old.agent.tag" . -}}
 {{- $oldAgentPullPolicy := include "nri-kube-events.compatibility.old.agent.pullPolicy" . -}}
 
-{{- if or $oldIntegrationRegistry $oldIntegrationRepository $oldIntegrationTag $oldIntegrationPullPolicy
-          $oldAgentRegistry $oldAgentRepository $oldAgentTag $oldAgentPullPolicy }}
+{{- if or $oldIntegrationRegistry $oldIntegrationRepository $oldIntegrationTag $oldIntegrationPullPolicy $oldAgentRegistry $oldAgentRepository $oldAgentTag $oldAgentPullPolicy }}
 Configuring image repository an tag under 'image' is no longer supported.
 This is the list values that we no longer support:
  - image.kubeEvents.registry

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -30,7 +30,7 @@ images:
     tag: 1.22.0
     pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
-  pullSecrets:
+  pullSecrets: []
   # - name: regsecret
 
 # -- Resources available for this pod


### PR DESCRIPTION
Running with helm 3.5.4

Before
```
/Users/pgallina/Downloads/darwin-amd64/helm template ./charts/nri-kube-events --set cluster=asd --set licenseKey=asd
Error: parse error at (nri-kube-events/templates/_helpers_compatibility.tpl:231): unclosed action

Use --debug flag to render out invalid YAML
```

After
```
/Users/pgallina/Downloads/darwin-amd64/helm template ./charts/nri-kube-events --set cluster=asd --set licenseKey=asd
---
# Source: nri-kube-events/templates/serviceaccount.yaml
[...]
```
