### PR TITLE
[chart] Fix `podLabels`

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,8 +5,20 @@
     ":disableDependencyDashboard"
   ],
   "enabledManagers": [
+    // Enable regex manager for image parsing. Go dependencies are managed by Dependabot.
+    "regex",
     // Managers for helm and helm-values. Go dependencies are managed by Dependabot.
-    "helm-values",
     "helmv3"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": [
+        '(^|/)values\.yaml$' // Is the same regex as "helmv3" but we have to change the regex.
+      ],
+      "datasourceTemplate": "docker",
+      "matchStrings": [
+        " *repository: (?<depName>.+)\n *tag: (?<currentValue>.+)"
+      ]
+    }
   ]
 }

--- a/charts/nri-kube-events/Chart.lock
+++ b/charts/nri-kube-events/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common-library
   repository: https://helm-charts.newrelic.com
-  version: 1.0.6
-digest: sha256:6297ce49be6028ef42ecdbe102046c96dbda7d8e42f759ba77f140592fb5dd3a
-generated: "2022-08-29T11:08:17.548533832Z"
+  version: 1.1.0
+digest: sha256:2784850d2fcf8acf99ea543b6ef0b7db24ba0b88f9c0aa83edbada0bebdc4fa8
+generated: "2022-09-07T14:30:14.154272627Z"

--- a/charts/nri-kube-events/Chart.lock
+++ b/charts/nri-kube-events/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://helm-charts.newrelic.com
   version: 1.1.0
 digest: sha256:2784850d2fcf8acf99ea543b6ef0b7db24ba0b88f9c0aa83edbada0bebdc4fa8
-generated: "2022-09-07T14:30:14.154272627Z"
+generated: "2022-09-12T16:59:30.970798+02:00"

--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -13,7 +13,7 @@ appVersion: 1.8.0
 
 dependencies:
   - name: common-library
-    version: 1.0.6
+    version: 1.1.0
     repository: "https://helm-charts.newrelic.com"
 
 maintainers:

--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -9,7 +9,7 @@ sources:
   - https://github.com/newrelic/infrastructure-agent/
 
 version: 2.2.8
-appVersion: 1.8.0
+appVersion: 1.8.2
 
 dependencies:
   - name: common-library

--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.2.7
+version: 2.2.8
 appVersion: 1.8.0
 
 dependencies:

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -20,7 +20,7 @@ spec:
         {{- toYaml .Values.podAnnotations | nindent 8}}
       {{- end }}
       labels:
-        {{- include "newrelic.common.labels" . | nindent 8 }}
+        {{- include "newrelic.common.labels.podLabels" . | nindent 8 }}
     spec:
       {{- with include "nri-kube-events.compatibility.images.renderPullSecrets" . }}
       imagePullSecrets:

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -20,14 +20,14 @@ images:
   integration:
     registry:
     repository: newrelic/nri-kube-events
-    tag: 1.8.0
+    tag:
     pullPolicy: IfNotPresent
   # -- Image for the New Relic Infrastructure Agent sidecar
   # @default -- See `values.yaml`
   agent:
     registry:
     repository: newrelic/k8s-events-forwarder
-    tag: 1.22.0
+    tag: 1.29.1
     pullPolicy: IfNotPresent
   # -- The secrets that are needed to pull images from a custom registry.
   pullSecrets: []


### PR DESCRIPTION
We were using `labels` instead of `podLabels` in the pods so we were not leveraging the `common-library` properly.

Fixes newrelic/nri-kube-events#142