### PR TITLE
[chart] Add tests for empty tag and fix it

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.2.8
+version: 2.2.9
 appVersion: 1.8.2
 
 dependencies:

--- a/charts/nri-kube-events/ci/test-bare-minimum-values.yaml
+++ b/charts/nri-kube-events/ci/test-bare-minimum-values.yaml
@@ -1,0 +1,3 @@
+global:
+  licenseKey: 1234567890abcdef1234567890abcdef12345678
+  cluster: test-cluster

--- a/charts/nri-kube-events/templates/_helpers_compatibility.tpl
+++ b/charts/nri-kube-events/templates/_helpers_compatibility.tpl
@@ -135,7 +135,7 @@ Creates the image string needed to pull the integration image respecting the bre
 
 {{- $oldTag := include "nri-kube-events.compatibility.old.integration.tag" . -}}
 {{- $newTag := .Values.images.integration.tag -}}
-{{- $tag := $oldTag | default $newTag -}}
+{{- $tag := $oldTag | default $newTag | default .Chart.AppVersion -}}
 
 {{- if $registry -}}
     {{- printf "%s/%s:%s" $registry $repository $tag -}}

--- a/charts/nri-kube-events/tests/images_test.yaml
+++ b/charts/nri-kube-events/tests/images_test.yaml
@@ -5,6 +5,18 @@ release:
   name: my-release
   namespace: my-namespace
 tests:
+  - it: by default the tag is not nil
+    set:
+      cluster: test-cluster
+      licenseKey: us-whatever
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ".*nil.*"
+      - notMatchRegex:
+          path: spec.template.spec.containers[1].image
+          pattern: ".*nil.*"
+
   - it: templates image correctly from the new values
     set:
       cluster: test-cluster


### PR DESCRIPTION
There are issues with `nri-bundle` while trying to merge it and it seems that there are issues in this chart. I put a screenshot in case the workflow logs rotate:

![Screenshot 2022-09-14 at 11 06 46](https://user-images.githubusercontent.com/53659978/190111787-da8a69be-e991-4edb-96d5-2a9809bd3c19.png)

The test I added in this PR failed with this before fixing it:

```
FAIL  test image compatibility layer   tests/images_test.yaml
       - by default the tag is not nil

               - asserts[0] `notMatchRegex` fail
                       Template:       nri-kube-events/templates/deployment.yaml
                       DocumentIndex:  0
                       Path:   spec.template.spec.containers[0].image
                       Expected NOT to match:
                               .*nil.*
                       Actual:
                               newrelic/nri-kube-events:%!s(<nil>)
```

Then I added the default filter to default to `appVersion` in case there is no tag defined.
