### PR TITLE
chore: Use new github output workflow commands

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           changed=$(ct --config .github/ct.yaml list-changed)
           if [[ -n "$changed" ]]; then
-            echo "::set-output name=changed::true"
+            echo "changed=true" >> $GITHUB_OUTPUT
           fi
       - name: Run helm unit tests
         if: steps.list-changed.outputs.changed == 'true'


### PR DESCRIPTION
This follows this [guide](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) to update they way outputs are set. This should silence some of the workflow warnings.
