### PR TITLE
chore: Increase dependabot limits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,16 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 10
     ignore:
       - dependency-name: "k8s.io/*"
   - package-ecosystem: docker
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 3
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
-    open-pull-requests-limit: 2
+    open-pull-requests-limit: 5


### PR DESCRIPTION
There are a bunch of stale dependencies that haven't been upgraded. Incresing the dependabot limits should help up address all of these upgrades quicker.
