### PR TITLE
chore: reformat all goimports

### DIFF
--- a/cmd/nri-kube-events/config.go
+++ b/cmd/nri-kube-events/config.go
@@ -7,10 +7,11 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/newrelic/nri-kube-events/pkg/sinks"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
+
+	"github.com/newrelic/nri-kube-events/pkg/sinks"
 )
 
 type config struct {

--- a/cmd/nri-kube-events/config_test.go
+++ b/cmd/nri-kube-events/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/newrelic/nri-kube-events/pkg/sinks"
 )
 

--- a/cmd/nri-kube-events/main.go
+++ b/cmd/nri-kube-events/main.go
@@ -14,18 +14,17 @@ import (
 	"syscall"
 	"time"
 
-	"k8s.io/client-go/tools/cache"
-
+	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/newrelic/nri-kube-events/pkg/events"
 	"github.com/newrelic/nri-kube-events/pkg/sinks"
-	"github.com/pkg/errors"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -14,18 +14,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/sethgrid/pester"
-
-	"github.com/prometheus/client_golang/prometheus/promauto"
-
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sirupsen/logrus"
-
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 	sdkEvent "github.com/newrelic/infra-integrations-sdk/data/event"
 	sdkIntegration "github.com/newrelic/infra-integrations-sdk/integration"
-	"github.com/newrelic/nri-kube-events/pkg/events"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/sethgrid/pester"
+	"github.com/sirupsen/logrus"
+
+	"github.com/newrelic/nri-kube-events/pkg/events"
 )
 
 func init() {

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -11,11 +11,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/newrelic/nri-kube-events/pkg/events"
-
 	"github.com/google/go-cmp/cmp"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/newrelic/nri-kube-events/pkg/events"
 )
 
 func TestFormatEntityID(t *testing.T) {

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -7,9 +7,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/newrelic/nri-kube-events/pkg/events"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/newrelic/nri-kube-events/pkg/events"
 )
 
 // SinkConfig defines the name and config map of an `events.Sink`

--- a/pkg/sinks/stdout.go
+++ b/pkg/sinks/stdout.go
@@ -7,9 +7,9 @@ import (
 	"encoding/json"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-kube-events/pkg/events"
-	"github.com/sirupsen/logrus"
 )
 
 func init() {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 // Package integration_test implements simple integration test against a local cluster, whose config is loaded from the kubeconfig file.
@@ -13,14 +14,15 @@ import (
 	"time"
 
 	sdkEvent "github.com/newrelic/infra-integrations-sdk/data/event"
-	"github.com/newrelic/nri-kube-events/pkg/events"
-	"github.com/newrelic/nri-kube-events/test/integration"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/newrelic/nri-kube-events/pkg/events"
+	"github.com/newrelic/nri-kube-events/test/integration"
 )
 
 // We must have a global TestAgentSink because the infrastructure-sdk attempts to register global flags when the

--- a/test/integration/test_agent_sink.go
+++ b/test/integration/test_agent_sink.go
@@ -11,9 +11,10 @@ import (
 	"time"
 
 	sdkEvent "github.com/newrelic/infra-integrations-sdk/data/event"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/newrelic/nri-kube-events/pkg/events"
 	"github.com/newrelic/nri-kube-events/pkg/sinks"
-	log "github.com/sirupsen/logrus"
 )
 
 // Must be in sync with unexported name in pkg/sinks/new_relic_infra.go:32.


### PR DESCRIPTION
Use the `-local` flag to reformat all the go imports
