### PR TITLE
Use native error wrapping

### DIFF
--- a/cmd/nri-kube-events/config.go
+++ b/cmd/nri-kube-events/config.go
@@ -3,11 +3,11 @@
 package main
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 
@@ -25,12 +25,15 @@ func loadConfig(file io.Reader) (config, error) {
 
 	contents, err := ioutil.ReadAll(file)
 	if err != nil {
-		return cfg, errors.Wrap(err, "could not read configuration file")
+		return cfg, fmt.Errorf("could not read configuration file: %w", err)
 	}
 
 	err = yaml.Unmarshal(contents, &cfg)
+	if err != nil {
+		return cfg, fmt.Errorf("could not parse configuration file: %w", err)
+	}
 
-	return cfg, errors.Wrap(err, "could not parse configuration file")
+	return cfg, nil
 }
 
 func mustLoadConfigFile(configFile string) config {

--- a/cmd/nri-kube-events/main.go
+++ b/cmd/nri-kube-events/main.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/informers"
@@ -158,7 +157,7 @@ func getClientset(kubeconfig string) (*kubernetes.Clientset, error) {
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot load kubernetes client configuration")
+		return nil, fmt.Errorf("cannot load kubernetes client configuration: %w", err)
 	}
 
 	return kubernetes.NewForConfig(conf)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/google/go-cmp v0.5.9
 	github.com/newrelic/infra-integrations-sdk v3.7.3+incompatible
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/sethgrid/pester v1.2.0
@@ -40,6 +39,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -155,7 +155,7 @@ func (ns *newRelicInfraSink) createEntity(kubeEvent events.KubeEvent) (*sdkInteg
 
 	e, err := ns.sdkIntegration.Entity(entityName, entityType)
 	if err != nil {
-		return nil, fmt.Errorf("could not initialise new SDK Entity: %w", err)
+		return nil, fmt.Errorf("could not initialize new SDK Entity: %w", err)
 	}
 
 	return e, nil

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -17,7 +17,6 @@ import (
 	sdkArgs "github.com/newrelic/infra-integrations-sdk/args"
 	sdkEvent "github.com/newrelic/infra-integrations-sdk/data/event"
 	sdkIntegration "github.com/newrelic/infra-integrations-sdk/integration"
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sethgrid/pester"
@@ -52,7 +51,7 @@ func createNewRelicInfraSink(config SinkConfig, integrationVersion string) (even
 
 	i, err := sdkIntegration.New(newRelicSDKName, integrationVersion, sdkIntegration.Args(&args))
 	if err != nil {
-		return nil, errors.Wrap(err, "error while initializing New Relic SDK integration")
+		return nil, fmt.Errorf("error while initializing New Relic SDK integration: %w", err)
 	}
 
 	logrus.Debugf("NewRelic sink configuration: agentTimeout=%s, clusterName=%s, agentEndpoint=%s",
@@ -120,13 +119,13 @@ func (ns *newRelicInfraSink) HandleEvent(kubeEvent events.KubeEvent) error {
 	e, err := ns.createEntity(kubeEvent)
 
 	if err != nil {
-		return errors.Wrap(err, "unable to create entity")
+		return fmt.Errorf("unable to create entity: %w", err)
 	}
 
 	flattenedEvent, err := flattenStruct(kubeEvent)
 
 	if err != nil {
-		return errors.Wrap(err, "could not flatten EventData struct")
+		return fmt.Errorf("could not flatten EventData struct: %w", err)
 	}
 
 	ns.decorateEvent(flattenedEvent)
@@ -138,13 +137,15 @@ func (ns *newRelicInfraSink) HandleEvent(kubeEvent events.KubeEvent) error {
 	)
 	err = e.AddEvent(event)
 	if err != nil {
-		return errors.Wrap(err, "couldn't add event")
+		return fmt.Errorf("couldn't add event: %w", err)
 	}
 
-	return errors.Wrap(
-		ns.sendIntegrationPayloadToAgent(),
-		"error sending data to agent",
-	)
+	err = ns.sendIntegrationPayloadToAgent()
+	if err != nil {
+		return fmt.Errorf("error sending data to agent: %w", err)
+	}
+
+	return nil
 }
 
 // createEntity creates the entity related to the event.
@@ -154,7 +155,7 @@ func (ns *newRelicInfraSink) createEntity(kubeEvent events.KubeEvent) (*sdkInteg
 
 	e, err := ns.sdkIntegration.Entity(entityName, entityType)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not initialise new SDK Entity")
+		return nil, fmt.Errorf("could not initialise new SDK Entity: %w", err)
 	}
 
 	return e, nil
@@ -193,7 +194,7 @@ func (ns *newRelicInfraSink) sendIntegrationPayloadToAgent() error {
 
 	request, err := http.NewRequest("POST", ns.agentEndpoint, bytes.NewBuffer(jsonBytes))
 	if err != nil {
-		return errors.Wrap(err, "unable to prepare request")
+		return fmt.Errorf("unable to prepare request: %w", err)
 	}
 
 	resp, err := ns.pesterClient.Do(request)

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-kube-events/pkg/events"
@@ -76,7 +75,7 @@ func CreateSinks(configs []SinkConfig, integrationVersion string) (map[string]ev
 
 		sink, err := factory(sinkConf, integrationVersion)
 		if err != nil {
-			return sinks, errors.Wrapf(err, "could not initialize sink %s", sinkConf.Name)
+			return sinks, fmt.Errorf("could not initialize sink %s: %w", sinkConf.Name, err)
 		}
 
 		logrus.Infof("Created sink: %s", sinkConf.Name)

--- a/pkg/sinks/stdout.go
+++ b/pkg/sinks/stdout.go
@@ -5,8 +5,8 @@ package sinks
 
 import (
 	"encoding/json"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/newrelic/nri-kube-events/pkg/events"
@@ -26,7 +26,7 @@ func (stdoutSink) HandleEvent(event events.KubeEvent) error {
 	b, err := json.Marshal(event)
 
 	if err != nil {
-		return errors.Wrap(err, "stdoutSink: could not marshal event")
+		return fmt.Errorf("stdoutSink: could not marshal event: %w", err)
 	}
 
 	logrus.Infof(string(b))


### PR DESCRIPTION
github.com/pkg/errors has been archived and the go stdlib supports error wrapping and unwrapping natively. So switch to using the stdlib way of handling errors.
