### PR TITLE
Upgrade and fixup skaffold deploys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ docker:
 	$(MAKE) compile GOOS=linux GOARCH=amd64
 	DOCKER_BUILDKIT=1 docker build . -t $(DOCKER_IMAGE_NAME)
 
+docker-push: docker
+	DOCKER_BUILDKIT=1 docker push $(DOCKER_IMAGE_NAME)
+
 docker-multiarch: compile-multiarch
 	@docker buildx build . -t $(DOCKER_IMAGE_NAME)
 

--- a/deploy/local.yaml.example
+++ b/deploy/local.yaml.example
@@ -1,8 +1,14 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nri-dev
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: nri-kube-events
-  namespace: default
+  namespace: nri-dev
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -24,7 +30,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: nri-kube-events
-    namespace: default
+    namespace: nri-dev
 ---
 apiVersion: v1
 data:
@@ -39,13 +45,13 @@ data:
 kind: ConfigMap
 metadata:
   name: nri-kube-events
-  namespace: default
+  namespace: nri-dev
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nri-kube-events
-  namespace: default
+  namespace: nri-dev
   labels:
     app: nri-kube-events
     app.kubernetes.io/name: nri-kube-events
@@ -61,7 +67,7 @@ spec:
     spec:
       containers:
         - name: kube-events
-          image: newrelic/nri-kube-events:1.7.0
+          image: newrelic/nri-kube-events:latest
           resources:
             limits:
               memory: "128Mi"
@@ -75,7 +81,7 @@ spec:
             - name: config-volume
               mountPath: /app/config
         - name: infra-agent
-          image: newrelic/k8s-events-forwarder:1.22.0
+          image: newrelic/k8s-events-forwarder:1.36.1
           resources:
             limits:
               memory: 128Mi
@@ -97,6 +103,8 @@ spec:
               value: "<ADD YOUR LICENSE KEY>"
 #            - name: "NRIA_VERBOSE"
 #              value: "1"
+            - name: NRIA_STAGING
+              value: "true"
             - name: NRIA_COLLECTOR_URL
               value: "https://staging-infra-api.newrelic.com"
           volumeMounts:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,14 +1,22 @@
-apiVersion: skaffold/v2alpha1
+apiVersion: skaffold/v4beta1
 kind: Config
 metadata:
   name: nri-kube-events
 build:
   artifacts:
-    - image: quay.io/newrelic/nri-kube-events
+  - image: newrelic/nri-kube-events
+    context: .
+    custom:
+      buildCommand: ./skaffold_build.sh
+      dependencies:
+        paths:
+        - "**/*.go"
+        - go.mod
+        - skaffold_build.sh
   tagPolicy:
     sha256: {}
+manifests:
+  rawYaml:
+  - deploy/local.yaml
 deploy:
-  kubectl:
-    manifests:
-    - deploy/local.yaml
-
+  kubectl: {}

--- a/skaffold_build.sh
+++ b/skaffold_build.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+
+MAKE_TARGET="docker"
+if [ "$PUSH_IMAGE" = true ]; then
+  MAKE_TARGET="docker-push"
+fi
+
+pushd "$BUILD_CONTEXT" > /dev/null
+DOCKER_IMAGE_NAME="$IMAGE"  make "$MAKE_TARGET"


### PR DESCRIPTION
This does a handful of things things:
- Runs the skaffold fix command to upgrade the skaffold file to be compatible with new versions of skaffold.
- Update the skaffold, docker and makefile setup to ensure that skaffold dev and skaffold run do the correct thing and deploy a dev app.
- Updates the local deployment to use a dev namespace instead of the default namespace so that it is easier to cleanup all the dev resources.

This should help with future dev and debug efforts.
