### PR TITLE
Move KubeEvent to common package

### DIFF
--- a/pkg/common/objects.go
+++ b/pkg/common/objects.go
@@ -1,0 +1,14 @@
+// Package common ...
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package common
+
+import v1 "k8s.io/api/core/v1"
+
+// KubeEvent represents a Kubernetes event. It specifies if this is the first
+// time the event is seen or if it's an update to a previous event.
+type KubeEvent struct {
+	Verb     string    `json:"verb"`
+	Event    *v1.Event `json:"event"`
+	OldEvent *v1.Event `json:"old_event,omitempty"`
+}

--- a/pkg/events/router_test.go
+++ b/pkg/events/router_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/newrelic/nri-kube-events/pkg/common"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	log "github.com/sirupsen/logrus"
@@ -146,7 +147,7 @@ type stubSink struct {
 	stubData string
 }
 
-func (s *stubSink) HandleEvent(kubeEvent KubeEvent) error {
+func (s *stubSink) HandleEvent(kubeEvent common.KubeEvent) error {
 	args := s.Called(kubeEvent)
 	return args.Error(0)
 }
@@ -175,13 +176,13 @@ func TestRouter_Run(t *testing.T) {
 
 	stubSink.On("HandleEvent", mock.AnythingOfType("KubeEvent")).Run(func(args mock.Arguments) {
 		log.Info("stub called")
-		ake := args.Get(0).(KubeEvent)
+		ake := args.Get(0).(common.KubeEvent)
 		assert.Equal(t, ke, ake.Event)
 		defer close(stopChan)
 	}).Return(nil).Once()
 
 	go func() {
-		r.workQueue <- KubeEvent{
+		r.workQueue <- common.KubeEvent{
 			Event: ke,
 		}
 	}()
@@ -218,7 +219,7 @@ func TestRouter_RunError(t *testing.T) {
 	}).Return(expectedError).Once()
 
 	go func() {
-		r.workQueue <- KubeEvent{
+		r.workQueue <- common.KubeEvent{
 			Event: ke,
 		}
 	}()

--- a/pkg/events/sink.go
+++ b/pkg/events/sink.go
@@ -6,13 +6,14 @@ package events
 import (
 	"time"
 
+	"github.com/newrelic/nri-kube-events/pkg/common"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Sink receives events from the router, process and publish them to a certain
 // destination (stdout, NewRelic platform, etc.).
 type Sink interface {
-	HandleEvent(kubeEvent KubeEvent) error
+	HandleEvent(kubeEvent common.KubeEvent) error
 }
 
 type observedSink struct {
@@ -20,7 +21,7 @@ type observedSink struct {
 	observer prometheus.Observer
 }
 
-func (o *observedSink) HandleEvent(kubeEvent KubeEvent) error {
+func (o *observedSink) HandleEvent(kubeEvent common.KubeEvent) error {
 	t := time.Now()
 	defer func() { o.observer.Observe(time.Since(t).Seconds()) }()
 

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sethgrid/pester"
 	"github.com/sirupsen/logrus"
 
+	"github.com/newrelic/nri-kube-events/pkg/common"
 	"github.com/newrelic/nri-kube-events/pkg/events"
 )
 
@@ -112,8 +113,7 @@ type newRelicInfraSink struct {
 }
 
 // HandleEvent sends the event to the New Relic Agent
-func (ns *newRelicInfraSink) HandleEvent(kubeEvent events.KubeEvent) error {
-
+func (ns *newRelicInfraSink) HandleEvent(kubeEvent common.KubeEvent) error {
 	defer ns.sdkIntegration.Clear()
 
 	e, err := ns.createEntity(kubeEvent)
@@ -149,8 +149,7 @@ func (ns *newRelicInfraSink) HandleEvent(kubeEvent events.KubeEvent) error {
 }
 
 // createEntity creates the entity related to the event.
-func (ns *newRelicInfraSink) createEntity(kubeEvent events.KubeEvent) (*sdkIntegration.Entity, error) {
-
+func (ns *newRelicInfraSink) createEntity(kubeEvent common.KubeEvent) (*sdkIntegration.Entity, error) {
 	entityType, entityName := formatEntityID(ns.clusterName, kubeEvent)
 
 	e, err := ns.sdkIntegration.Entity(entityName, entityType)
@@ -171,7 +170,7 @@ func (ns *newRelicInfraSink) createEntity(kubeEvent events.KubeEvent) (*sdkInteg
 //
 // Example node entityName:
 // ("k8s:fsi-cluster-explorer:node", "worker-node-1")
-func formatEntityID(clusterName string, kubeEvent events.KubeEvent) (string, string) {
+func formatEntityID(clusterName string, kubeEvent common.KubeEvent) (string, string) {
 	parts := []string{newRelicNamespace}
 
 	parts = append(parts, clusterName)

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -15,7 +15,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/newrelic/nri-kube-events/pkg/events"
+	"github.com/newrelic/nri-kube-events/pkg/common"
 )
 
 func TestFormatEntityID(t *testing.T) {
@@ -58,7 +58,7 @@ func TestFormatEntityID(t *testing.T) {
 
 		entityType, entityName := formatEntityID(
 			testCase.clusterName,
-			events.KubeEvent{
+			common.KubeEvent{
 				Event: &v1.Event{
 					InvolvedObject: testCase.involvedObject,
 				},
@@ -118,7 +118,7 @@ func TestNewRelicSinkIntegration(t *testing.T) {
 		},
 	}
 	sink, _ := createNewRelicInfraSink(config, "0.0.0")
-	err = sink.HandleEvent(events.KubeEvent{
+	err = sink.HandleEvent(common.KubeEvent{
 		Verb: "ADDED",
 		Event: &v1.Event{
 			Message: "The event message",
@@ -151,7 +151,7 @@ func TestNewRelicInfraSink_HandleEvent_AddEventError(t *testing.T) {
 		},
 	}
 	sink, _ := createNewRelicInfraSink(config, "0.0.0")
-	err := sink.HandleEvent(events.KubeEvent{
+	err := sink.HandleEvent(common.KubeEvent{
 		Verb: "ADDED",
 		Event: &v1.Event{
 			Message: "",
@@ -181,7 +181,7 @@ func TestNewRelicInfraSink_HandleEvent_AddEventError(t *testing.T) {
 }
 
 func TestFlattenStruct(t *testing.T) {
-	got, _ := flattenStruct(events.KubeEvent{Verb: "UPDATE", Event: &v1.Event{
+	got, _ := flattenStruct(common.KubeEvent{Verb: "UPDATE", Event: &v1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "test",
 			Labels: map[string]string{

--- a/pkg/sinks/stdout.go
+++ b/pkg/sinks/stdout.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/newrelic/nri-kube-events/pkg/common"
 	"github.com/newrelic/nri-kube-events/pkg/events"
 )
 
@@ -22,7 +23,7 @@ func createStdoutSink(_ SinkConfig, _ string) (events.Sink, error) {
 
 type stdoutSink struct{}
 
-func (stdoutSink) HandleEvent(event events.KubeEvent) error {
+func (stdoutSink) HandleEvent(event common.KubeEvent) error {
 	b, err := json.Marshal(event)
 
 	if err != nil {

--- a/test/integration/test_agent_sink.go
+++ b/test/integration/test_agent_sink.go
@@ -13,6 +13,7 @@ import (
 	sdkEvent "github.com/newrelic/infra-integrations-sdk/data/event"
 	log "github.com/sirupsen/logrus"
 
+	"github.com/newrelic/nri-kube-events/pkg/common"
 	"github.com/newrelic/nri-kube-events/pkg/events"
 	"github.com/newrelic/nri-kube-events/pkg/sinks"
 )
@@ -61,7 +62,7 @@ func NewTestAgentSink() *TestAgentSink {
 }
 
 // HandleEvent sends a notification to the event received channel and then forwards it to the underlying sink.
-func (tas *TestAgentSink) HandleEvent(kubeEvent events.KubeEvent) error {
+func (tas *TestAgentSink) HandleEvent(kubeEvent common.KubeEvent) error {
 	tas.eventReceivedChan <- struct{}{}
 	return tas.agentSink.HandleEvent(kubeEvent)
 }


### PR DESCRIPTION
KubeEvent is a shared API between the data we get from the Informers and the
data we send to the sinks.

Since the event routers and sinks should be separate packages and we are working
towards that goal, pulling KubeEvent into a common package that is shared helps
make the API cleaner.

In the future we might add KubePod, KubeNode etc as we write informers that send
data based on other k8s objects.
