### PR TITLE
Add a local golangci-lint config and autofix fixable issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,68 @@
+run:
+  timeout: 5m
+
+linters-settings:
+  dupl:
+    threshold: 100
+  gci:
+    local-prefixes: github.com/newrelic/nri-kube-events
+  gocyclo:
+    min-complexity: 10
+  golint:
+    min-confidence: 0.8
+  gomnd:
+    settings:
+      mnd:
+        checks: argument,case,condition,return
+  govet:
+    check-shadowing: true
+  maligned:
+    suggest-new: true
+  misspell:
+    locale: US
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+linters:
+  disable-all: true
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - gocognit
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - maligned
+    - misspell
+    - nestif
+    - nilerr
+    - noctx
+    - prealloc
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 linters-settings:
   dupl:
     threshold: 100
-  gci:
+  goimports:
     local-prefixes: github.com/newrelic/nri-kube-events
   gocyclo:
     min-complexity: 10

--- a/cmd/nri-kube-events/config.go
+++ b/cmd/nri-kube-events/config.go
@@ -5,7 +5,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -22,7 +21,7 @@ type config struct {
 func loadConfig(file io.Reader) (config, error) {
 	var cfg config
 
-	contents, err := ioutil.ReadAll(file)
+	contents, err := io.ReadAll(file)
 	if err != nil {
 		return cfg, fmt.Errorf("could not read configuration file: %w", err)
 	}

--- a/cmd/nri-kube-events/config.go
+++ b/cmd/nri-kube-events/config.go
@@ -20,7 +20,6 @@ type config struct {
 }
 
 func loadConfig(file io.Reader) (config, error) {
-
 	var cfg config
 
 	contents, err := ioutil.ReadAll(file)

--- a/cmd/nri-kube-events/main.go
+++ b/cmd/nri-kube-events/main.go
@@ -134,7 +134,7 @@ func createEventsInformer(stopChan <-chan struct{}) (cache.SharedIndexInformer, 
 	sharedInformers.Start(stopChan)
 
 	// wait for the internal cache to sync. This is the only time the cache will be filled,
-	// since we've set resync to 0. This behaviour is very important,
+	// since we've set resync to 0. This behavior is very important,
 	// because we will delete the cache to prevent duplicate events from being sent.
 	// If we remove this cache-deletion and you restart nri-kube-events, we will sent lots of duplicated events
 	sharedInformers.WaitForCacheSync(stopChan)

--- a/pkg/events/router_test.go
+++ b/pkg/events/router_test.go
@@ -113,7 +113,6 @@ func TestNewRouter(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			tt.args.informer.
 				On("AddEventHandler", mock.AnythingOfType("cache.ResourceEventHandlerFuncs")).
 				Once()

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -184,7 +184,7 @@ func formatEntityID(clusterName string, kubeEvent common.KubeEvent) (string, str
 func (ns *newRelicInfraSink) sendIntegrationPayloadToAgent() error {
 	jsonBytes, err := json.Marshal(ns.sdkIntegration)
 	if err != nil {
-		return fmt.Errorf("unable to marshal data: %v", err)
+		return fmt.Errorf("unable to marshal data: %w", err)
 	}
 
 	request, err := http.NewRequest("POST", ns.agentEndpoint, bytes.NewBuffer(jsonBytes))
@@ -196,7 +196,7 @@ func (ns *newRelicInfraSink) sendIntegrationPayloadToAgent() error {
 
 	if err != nil {
 		ns.metrics.httpTotalFailures.Inc()
-		return fmt.Errorf("HTTP transport error: %v", err)
+		return fmt.Errorf("HTTP transport error: %w", err)
 	}
 
 	disposeBody(resp)

--- a/pkg/sinks/new_relic_infra.go
+++ b/pkg/sinks/new_relic_infra.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
@@ -219,7 +218,7 @@ func (ns *newRelicInfraSink) sendIntegrationPayloadToAgent() error {
 // If the Body is not both read to EOF and closed, the Client's underlying RoundTripper (typically Transport)
 // may not be able to re-use a persistent TCP connection to the server for a subsequent "keep-alive" request.
 func disposeBody(response *http.Response) {
-	if _, err := io.Copy(ioutil.Discard, response.Body); err != nil {
+	if _, err := io.Copy(io.Discard, response.Body); err != nil {
 		logrus.Debugf("warning: could not discard response body: %v", err)
 	}
 	if err := response.Body.Close(); err != nil {

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -4,7 +4,7 @@ package sinks
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -77,7 +77,7 @@ func TestNewRelicSinkIntegration_HandleEvent_Success(t *testing.T) {
 	_ = os.Setenv("METADATA", "true")
 	_ = os.Setenv("NRI_KUBE_EVENTS_myCustomAttribute", "attrValue")
 	defer os.Clearenv()
-	expectedPostJSON, err := ioutil.ReadFile("./testdata/event_data.json")
+	expectedPostJSON, err := os.ReadFile("./testdata/event_data.json")
 	if err != nil {
 		t.Fatalf("could not read test_post_data.json: %v", err)
 	}
@@ -87,7 +87,7 @@ func TestNewRelicSinkIntegration_HandleEvent_Success(t *testing.T) {
 	}
 
 	responseHandler := func(w http.ResponseWriter, r *http.Request) {
-		body, err := ioutil.ReadAll(r.Body)
+		body, err := io.ReadAll(r.Body)
 
 		defer func() {
 			_ = r.Body.Close()

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -87,19 +87,19 @@ func TestNewRelicSinkIntegration_HandleEvent_Success(t *testing.T) {
 	}
 
 	responseHandler := func(w http.ResponseWriter, r *http.Request) {
-		body, err := io.ReadAll(r.Body)
+		body, err2 := io.ReadAll(r.Body)
 
 		defer func() {
 			_ = r.Body.Close()
 		}()
 
-		if err != nil {
-			t.Fatalf("error reading request body: %v", err)
+		if err2 != nil {
+			t.Fatalf("error reading request body: %v", err2)
 		}
 
 		var postData interface{}
-		if err = json.Unmarshal(body, &postData); err != nil {
-			t.Fatalf("error unmarshalling request body: %v", err)
+		if err2 = json.Unmarshal(body, &postData); err2 != nil {
+			t.Fatalf("error unmarshalling request body: %v", err2)
 		}
 
 		if diff := cmp.Diff(expectedData, postData); diff != "" {

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -55,7 +55,6 @@ func TestFormatEntityID(t *testing.T) {
 	}
 
 	for i, testCase := range tt {
-
 		entityType, entityName := formatEntityID(
 			testCase.clusterName,
 			common.KubeEvent{

--- a/pkg/sinks/sinks.go
+++ b/pkg/sinks/sinks.go
@@ -70,7 +70,6 @@ func Create(configs []SinkConfig, integrationVersion string) (map[string]Sink, e
 	sinks := make(map[string]Sink)
 
 	for _, sinkConf := range configs {
-
 		var ok bool
 		var factory sinkFactory
 

--- a/test/integration/test_agent_sink.go
+++ b/test/integration/test_agent_sink.go
@@ -196,7 +196,6 @@ func isEventSubset(old, new *sdkEvent.Event) bool {
 				return false
 			}
 		}
-
 	}
 
 	return true

--- a/test/integration/test_agent_sink.go
+++ b/test/integration/test_agent_sink.go
@@ -2,7 +2,7 @@ package integration
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -78,7 +78,7 @@ func (tas *TestAgentSink) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	}
 
 	defer r.Body.Close() // nolint:errcheck
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Fatalf("error reading request body: %v", err)
 	}


### PR DESCRIPTION
Add a local config so that IDEs can report lint issues. Otherwise lint issues
are not detected until actions are run.
Also run the lint autofixer to fix common issues.
