### PR TITLE
Add Resource Settings for Kube-events' Forwarder

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.3.1
+version: 2.3.2
 appVersion: 1.9.1
 
 dependencies:

--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,7 +8,7 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.3.2
+version: 2.3.1
 appVersion: 1.9.1
 
 dependencies:

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- if .Values.forwarder.resources }}
+          {{- if ((.Values.forwarder).resources) }}
           resources:
             {{- toYaml .Values.forwarder.resources | nindent 12 }}
           {{- end }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,9 +79,9 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- if .Values.resources }}
+          {{- if .Values.forwarder.resources }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.forwarder.resources | nindent 12 }}
           {{- end }}
         {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,9 +79,10 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- if .Values.forwarder.resources }}
+          {{- $forwarder := .Values.forwarder | default dict }}
+          {{- if $forwarder.resources }}
           resources:
-            {{- toYaml .Values.forwarder.resources | nindent 12 }}
+            {{- toYaml $forwarder.resources | nindent 12 }}
           {{- end }}
         {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,9 +79,9 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- if .Values.forwarder.resources }}
+          {{- if .Values.resources }}
           resources:
-            {{- toYaml .Values.forwarder.resources | nindent 12 }}
+            {{- toYaml .Values.resources | nindent 12 }}
           {{- end }}
         {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- if .Values.forwarder }}
+          {{- if .Values.forwarder.resources }}
           resources:
             {{- toYaml .Values.forwarder.resources | nindent 12 }}
           {{- end }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,10 +79,9 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
-          {{- $forwarder := .Values.forwarder | default dict }}
-          {{- if $forwarder.resources }}
+          {{- if .Values.forwarder }}
           resources:
-            {{- toYaml $forwarder.resources | nindent 12 }}
+            {{- toYaml .Values.forwarder.resources | nindent 12 }}
           {{- end }}
         {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}

--- a/charts/nri-kube-events/templates/deployment.yaml
+++ b/charts/nri-kube-events/templates/deployment.yaml
@@ -79,6 +79,10 @@ spec:
             - name: config
               mountPath: /etc/newrelic-infra.yml
               subPath: newrelic-infra.yml
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
         {{- end }}
       serviceAccountName: {{ include "newrelic.common.serviceAccount.name" . }}
       volumes:

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -45,11 +45,11 @@ resources: {}
 forwarder:
   resources:
     limits:
-      cpu: 300m
-      memory: 500Mi
+      cpu: 100m
+      memory: 128Mi
     requests:
       cpu: 100m
-      memory: 150Mi
+      memory: 128Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -33,7 +33,7 @@ images:
   pullSecrets: []
   # - name: regsecret
 
-# -- Resources available for this pod
+# -- Resources for the integration container
 resources: {}
   # limits:
   #   cpu: 100m
@@ -42,6 +42,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+# -- Resources for the agent/forwarder container
 forwarder:
   resources: {}
     # limits:

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -34,13 +34,22 @@ images:
   # - name: regsecret
 
 # -- Resources available for this pod
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+forwarder:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 150Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -42,6 +42,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+forwarder:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 150Mi
+
 rbac:
   # -- Specifies whether RBAC resources should be created
   create: true

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -34,22 +34,13 @@ images:
   # - name: regsecret
 
 # -- Resources available for this pod
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-# forwarder:
-#   resources:
-#     limits:
-#       cpu: 100m
-#       memory: 128Mi
-#     requests:
-#       cpu: 100m
-#       memory: 128Mi
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -34,13 +34,22 @@ images:
   # - name: regsecret
 
 # -- Resources available for this pod
-resources:
-  limits:
-    cpu: 100m
-    memory: 128Mi
-  requests:
-    cpu: 100m
-    memory: 128Mi
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+forwarder:
+  resources: {}
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -42,14 +42,14 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-forwarder:
-  resources:
-    limits:
-      cpu: 100m
-      memory: 128Mi
-    requests:
-      cpu: 100m
-      memory: 128Mi
+# forwarder:
+#   resources:
+#     limits:
+#       cpu: 100m
+#       memory: 128Mi
+#     requests:
+#       cpu: 100m
+#       memory: 128Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -34,22 +34,13 @@ images:
   # - name: regsecret
 
 # -- Resources available for this pod
-resources: {}
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-forwarder:
-  resources:
-    limits:
-      cpu: 300m
-      memory: 500Mi
-    requests:
-      cpu: 100m
-      memory: 150Mi
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
 
 rbac:
   # -- Specifies whether RBAC resources should be created

--- a/charts/nri-kube-events/values.yaml
+++ b/charts/nri-kube-events/values.yaml
@@ -42,7 +42,7 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
-# -- Resources for the agent/forwarder container
+# -- Resources for the forwarder sidecar container
 forwarder:
   resources: {}
     # limits:


### PR DESCRIPTION
# Description
A customer found that the resource settings for kube-events' forward sidecar is not generated (https://github.com/newrelic/nri-kube-events/issues/186) although the resource is set for the pod in values.yaml

# Changes
I make up the resource setting section for the kube-events' forward sidecar

# Tests have been done
build the helm chart change locally and run
`nri-bundle %  helm template nrk8s ./ --values /Users/xqi/Documents/GitHub/helm-charts/values.yaml  --dry-run >> ~/Desktop/new.yaml `

The generated yaml

```
containers:
        - name: kube-events
          ...
        - name: forwarder
          ...
          resources:
            limits:
              cpu: 300m
              memory: 500Mi
            requests:
              cpu: 100m
              memory: 128Mi
```