### PR TITLE
Update ct linter to not check for version bumps

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -5,3 +5,7 @@ target-branch: main
 
 chart-repos:
   - newrelic=https://helm-charts.newrelic.com
+
+# Charts will be released manually.
+check-version-increment: false
+


### PR DESCRIPTION
This makes it easier to make changes to the helm chart
values without needing to also bump the version in the
same PR.
