### PR TITLE
Update trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,0 @@
-# We are running the 2.16.0 version of github.com/emicklei/go-restful that had the fix backported, but trivy still points it out as false-positive
-# This is going to be fixed by 2.15 of the kubernetes client go, they decided not to backport the fix since they are not using the impacted feature.
-CVE-2022-1996


### PR DESCRIPTION
We no longer need to ignore this particular CVE
since the relevant deps were updated.
