### PR TITLE
Bump chart version and update maintainers

### DIFF
--- a/charts/nri-kube-events/Chart.yaml
+++ b/charts/nri-kube-events/Chart.yaml
@@ -8,8 +8,8 @@ sources:
   - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
   - https://github.com/newrelic/infrastructure-agent/
 
-version: 2.3.1
-appVersion: 1.9.1
+version: 2.3.2
+appVersion: 1.9.2
 
 dependencies:
   - name: common-library
@@ -17,22 +17,24 @@ dependencies:
     repository: "https://helm-charts.newrelic.com"
 
 maintainers:
-  - name: alvarocabanas
-    url: https://github.com/alvarocabanas
-  - name: carlossscastro
-    url: https://github.com/carlossscastro
-  - name: sigilioso
-    url: https://github.com/sigilioso
-  - name: gsanchezgavier
-    url: https://github.com/gsanchezgavier
-  - name: kang-makes
-    url: https://github.com/kang-makes
-  - name: marcsanmi
-    url: https://github.com/marcsanmi
-  - name: paologallinaharbur
-    url: https://github.com/paologallinaharbur
-  - name: roobre
-    url: https://github.com/roobre
+  - name: nserrino
+    url: https://github.com/nserrino
+  - name: philkuz
+    url: https://github.com/philkuz
+  - name: htroisi
+    url: https://github.com/htroisi
+  - name: juanjjaramillo
+    url: https://github.com/juanjjaramillo
+  - name: svetlanabrennan
+    url: https://github.com/svetlanabrennan
+  - name: nrepai
+    url: https://github.com/nrepai
+  - name: csongnr
+    url: https://github.com/csongnr
+  - name: vuqtran88
+    url: https://github.com/vuqtran88
+  - name: xqi-nr
+    url: https://github.com/xqi-nr
 
 keywords:
   - infrastructure

--- a/charts/nri-kube-events/README.md
+++ b/charts/nri-kube-events/README.md
@@ -1,6 +1,6 @@
 # nri-kube-events
 
-![Version: 2.2.6](https://img.shields.io/badge/Version-2.2.6-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![AppVersion: 1.9.2](https://img.shields.io/badge/AppVersion-1.9.2-informational?style=flat-square)
 
 A Helm chart to deploy the New Relic Kube Events router
 
@@ -72,11 +72,12 @@ Options that can be defined globally include `affinity`, `nodeSelector`, `tolera
 
 ## Maintainers
 
-* [alvarocabanas](https://github.com/alvarocabanas)
-* [carlossscastro](https://github.com/carlossscastro)
-* [sigilioso](https://github.com/sigilioso)
-* [gsanchezgavier](https://github.com/gsanchezgavier)
-* [kang-makes](https://github.com/kang-makes)
-* [marcsanmi](https://github.com/marcsanmi)
-* [paologallinaharbur](https://github.com/paologallinaharbur)
-* [roobre](https://github.com/roobre)
+* [nserrino](https://github.com/nserrino)
+* [philkuz](https://github.com/philkuz)
+* [htroisi](https://github.com/htroisi)
+* [juanjjaramillo](https://github.com/juanjjaramillo)
+* [svetlanabrennan](https://github.com/svetlanabrennan)
+* [nrepai](https://github.com/nrepai)
+* [csongnr](https://github.com/csongnr)
+* [vuqtran88](https://github.com/vuqtran88)
+* [xqi-nr](https://github.com/xqi-nr)


### PR DESCRIPTION
Changes:

- Bump app version to recently released `v1.9.2`
- Bump chart version
- Update `README` using `helm-docs`. 