### PR TITLE
Tell chart releaser to skip existing charts

### DIFF
--- a/.github/workflows/release-chart.yml
+++ b/.github/workflows/release-chart.yml
@@ -40,4 +40,5 @@ jobs:
       - name: Release workload charts
         uses: helm/chart-releaser-action@v1.5.0
         env:
+          CR_SKIP_EXISTING: true
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Since chart releaser triggers on ever push to main, we need this
flag now that we allow bumping chart details without bumping
the chart version (https://github.com/newrelic/nri-kube-events/pull/199). This prevents the releaser from trying to overwrite
an existing release and failing.
