### PR TITLE
Load docker image when building

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -166,6 +166,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           context: .
+          load: true
           platforms: |
             linux/amd64
           tags: e2e/nri-kube-events:test


### PR DESCRIPTION
This is a followup to #208 
buildkit doesn't load images by default since it might be building multiple platforms. So we need to explicitly tell buildkit to load the image so that minikube can find it later. 

Signed-off-by: Vihang Mehta <vmehta@newrelic.com>
