### PR TITLE
Fix image download and load

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -168,10 +168,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: nri-kube-events
-          path: nri-kube-events.tar
       - name: Load image for chart testing
         run: |
           minikube image load nri-kube-events.tar
+          minikube image ls
           kubectl create ns ct
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
`minikube load image` seems to silently fail when the image path is wrong.
This fixes the path and includes a `minikube image ls` to check that the loaded image now exists.