### PR TITLE
Fix push_pr workflow

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -50,7 +50,7 @@ jobs:
           helm plugin install https://github.com/quintush/helm-unittest
           for chart in $(ct --config .github/ct.yaml list-changed); do
             if [ -d "$chart/tests/" ]; then
-              helm unittest -3 $chart
+              helm unittest $chart
             else
               echo "No unit tests found for $chart"
             fi


### PR DESCRIPTION
Fixes: https://github.com/newrelic/nri-kube-events/actions/runs/4683262761/jobs/8298149558?pr=223

Now that https://github.com/helm-unittest/helm-unittest/pull/114 has made Helm3 support the default, we no longer need to specify Helm3. 