### PR TITLE
Add common utils

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ linters-settings:
   goimports:
     local-prefixes: github.com/newrelic/nri-kube-events
   gocyclo:
-    min-complexity: 10
+    min-complexity: 20
   golint:
     min-confidence: 0.8
   gomnd:

--- a/pkg/common/utils.go
+++ b/pkg/common/utils.go
@@ -1,0 +1,84 @@
+// Package common ...
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"unicode/utf8"
+)
+
+// LimitSplit splits the input string into multiple strings at the specified limit
+// taking care not to split mid-rune.
+func LimitSplit(input string, limit int) []string {
+	if limit <= 0 {
+		return []string{input}
+	}
+
+	var splits []string
+	for len(input) > limit {
+		boundary := limit
+		// Check if this is a run boundary, else go backwards upto UTFMax bytes to look for
+		// a boundary. If one isn't found in max bytes, give up and split anyway.
+		for !utf8.RuneStart(input[boundary]) && boundary >= limit-utf8.UTFMax {
+			boundary--
+		}
+		splits = append(splits, input[:boundary])
+		input = input[boundary:]
+	}
+	if len(input) > 0 {
+		splits = append(splits, input)
+	}
+	return splits
+}
+
+func FlattenStruct(v interface{}) (map[string]interface{}, error) {
+	m := make(map[string]interface{})
+
+	data, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var unflattened map[string]interface{}
+	err = json.Unmarshal(data, &unflattened)
+	if err != nil {
+		return nil, err
+	}
+
+	var doFlatten func(string, interface{}, map[string]interface{})
+
+	doFlatten = func(key string, v interface{}, m map[string]interface{}) {
+		switch parsedType := v.(type) {
+		case map[string]interface{}:
+			for k, n := range parsedType {
+				doFlatten(key+"."+k, n, m)
+			}
+		case []interface{}:
+			for i, n := range parsedType {
+				doFlatten(key+fmt.Sprintf("[%d]", i), n, m)
+			}
+		case string:
+			// ignore empty strings
+			if parsedType == "" {
+				return
+			}
+
+			m[key] = v
+
+		default:
+			// ignore nil values
+			if v == nil {
+				return
+			}
+
+			m[key] = v
+		}
+	}
+
+	for k, v := range unflattened {
+		doFlatten(k, v, m)
+	}
+
+	return m, nil
+}

--- a/pkg/common/utils_test.go
+++ b/pkg/common/utils_test.go
@@ -1,0 +1,88 @@
+// Copyright 2019 New Relic Corporation. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+package common_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/newrelic/nri-kube-events/pkg/common"
+)
+
+func TestLimitSplit(t *testing.T) {
+	tests := []struct {
+		input  string
+		limit  int
+		output []string
+	}{
+		{
+			input:  "short string",
+			limit:  20,
+			output: []string{"short string"},
+		},
+		{
+			input:  "very very very long string",
+			limit:  20,
+			output: []string{"very very very long ", "string"},
+		},
+		{
+			input:  "",
+			limit:  20,
+			output: nil,
+		},
+		{
+			input:  "short",
+			limit:  0,
+			output: []string{"short"},
+		},
+		{
+			input:  "日本語",
+			limit:  4,
+			output: []string{"日", "本", "語"},
+		},
+		{
+			input:  "bad utf8 \xbd\xb2\x3d\xbc\x20\xe2\x8c\x98",
+			limit:  8,
+			output: []string{"bad utf8", " \xbd\xb2\x3d\xbc\x20", "\xe2\x8c\x98"},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.output, common.LimitSplit(test.input, test.limit))
+	}
+}
+
+func TestFlattenStruct(t *testing.T) {
+	got, _ := common.FlattenStruct(common.KubeEvent{Verb: "UPDATE", Event: &v1.Event{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+			Labels: map[string]string{
+				"test_label1": "test_value1",
+				"test_label2": "test_value2",
+			},
+			Finalizers: []string{"1", "2"},
+		},
+		Count: 10,
+		InvolvedObject: v1.ObjectReference{
+			Kind:      "Pod",
+			Namespace: "test_namespace",
+		},
+	}})
+
+	want := map[string]interface{}{
+		"event.count":                       float64(10),
+		"event.metadata.name":               "test",
+		"event.metadata.labels.test_label1": "test_value1",
+		"event.metadata.labels.test_label2": "test_value2",
+		"event.involvedObject.kind":         "Pod",
+		"event.involvedObject.namespace":    "test_namespace",
+		"event.metadata.finalizers[0]":      "1",
+		"event.metadata.finalizers[1]":      "2",
+		"verb":                              "UPDATE",
+	}
+
+	assert.Equal(t, want, got)
+}

--- a/pkg/sinks/new_relic_infra_test.go
+++ b/pkg/sinks/new_relic_infra_test.go
@@ -178,37 +178,3 @@ func TestNewRelicInfraSink_HandleEvent_AddEventError(t *testing.T) {
 		t.Errorf("wanted error with message '%s' got: '%v'", wantedError, err)
 	}
 }
-
-func TestFlattenStruct(t *testing.T) {
-	got, _ := flattenStruct(common.KubeEvent{Verb: "UPDATE", Event: &v1.Event{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-			Labels: map[string]string{
-				"test_label1": "test_value1",
-				"test_label2": "test_value2",
-			},
-			Finalizers: []string{"1", "2"},
-		},
-		Count: 10,
-		InvolvedObject: v1.ObjectReference{
-			Kind:      "Pod",
-			Namespace: "test_namespace",
-		},
-	}})
-
-	want := map[string]interface{}{
-		"event.count":                       float64(10),
-		"event.metadata.name":               "test",
-		"event.metadata.labels.test_label1": "test_value1",
-		"event.metadata.labels.test_label2": "test_value2",
-		"event.involvedObject.kind":         "Pod",
-		"event.involvedObject.namespace":    "test_namespace",
-		"event.metadata.finalizers[0]":      "1",
-		"event.metadata.finalizers[1]":      "2",
-		"verb":                              "UPDATE",
-	}
-
-	if diff := cmp.Diff(want, got); diff != "" {
-		t.Errorf("flattenStruct() mismatch (-want +got):\n%s", diff)
-	}
-}


### PR DESCRIPTION
Moves flattenStruct into the common package under utils and also adds a helper to split strings based on length without splitting runes.
