### PR TITLE
Update K8s Versions in E2E tests

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.7.2
         with:
-          minikube version: v1.29.0
+          minikube version: v1.30.1
           kubernetes version: ${{ matrix.k8sVersion }}
           container runtime: ${{ matrix.cri }}
           driver: docker

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -134,16 +134,7 @@ jobs:
       fail-fast: false
       matrix:
         k8sVersion: [ "1.23.17", "1.24.17", "1.25.13", "1.26.8", "1.27.5" ]
-        cri: [ docker, containerd ]
-        exclude:
-          - k8sVersion: v1.24.17
-            cri: docker
-          - k8sVersion: v1.25.13
-            cri: docker
-          - k8sVersion: v1.26.8
-            cri: docker
-          - k8sVersion: v1.27.5
-            cri: docker
+        cri: [ containerd ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -133,20 +133,16 @@ jobs:
       max-parallel: 4
       fail-fast: false
       matrix:
-        k8sVersion: [ v1.16.15, v1.21.14, v1.22.17, v1.23.17, v1.24.11, v1.25.7, v1.26.2 ]
+        k8sVersion: [ "1.23.17", "1.24.17", "1.25.13", "1.26.8", "1.27.5" ]
         cri: [ docker, containerd ]
         exclude:
-          - k8sVersion: v1.16.15
-            cri: containerd
-          - k8sVersion: v1.21.14
-            cri: containerd
-          - k8sVersion: v1.22.17
-            cri: containerd
-          - k8sVersion: v1.24.11
+          - k8sVersion: v1.24.17
             cri: docker
-          - k8sVersion: v1.25.7
+          - k8sVersion: v1.25.13
             cri: docker
-          - k8sVersion: v1.26.2
+          - k8sVersion: v1.26.8
+            cri: docker
+          - k8sVersion: v1.27.5
             cri: docker
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -156,9 +156,9 @@ jobs:
         with:
           minikube version: v1.30.1
           kubernetes version: ${{ matrix.k8sVersion }}
-          container runtime: ${{ matrix.cri }}
           driver: docker
           github token: ${{ secrets.GITHUB_TOKEN }}
+          start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"
       - name: Run e2e tests
         run: make test-integration
       - name: Download Image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Enhancement
+- Update K8s Versions in E2E Tests by @xqi-nr in [#275](https://github.com/newrelic/nri-kube-events/pull/275)
+
 ## 2.1.2
 
 ## What's Changed


### PR DESCRIPTION
## Which problem is this PR solving?

The K8s versions in E2e Tests are old.

## Short description of the changes

Check the GitHub workflows that run for PR pushes and:
Remove any references to Kubernetes versions 1.22 or older
Add to tests Kubernetes versions: 1.23.17, 1.24.17, 1.25.13, 1.26.8, 1.27.5

The --container-runtime flag was deprecated in k8s 1.24, and removed in k8s 1.27
So the e2e test for 1.27.5 with minikube fails
https://github.com/kubernetes/minikube/issues/16112
https://github.com/kubernetes/minikube/pull/16124

So I make the change `start args: "--nodes=2 --container-runtime=${{ matrix.cri }}"` which is learned from `nri-kubenetes` repo

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)

## New Tests?


## Checklist:
- [x] Add changelog entry following the [contributing guide](../CONTRIBUTING.md#pull-requests)
- [x] Tests have been updated