### PR TITLE
fix(ci): Make GitHub runner consistent on all workflows

### DIFF
--- a/.github/workflows/push_pr.yml
+++ b/.github/workflows/push_pr.yml
@@ -59,7 +59,7 @@ jobs:
 
   docker-build:
     name: Build docker image for integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
       DOCKER_BUILDKIT: '1'
@@ -125,7 +125,7 @@ jobs:
 
   test-integration:
     name: Run integration tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [ docker-build ]
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## Which problem is this PR solving?

Workflow `push_pr` is the only workflow that does not use a GitHub runner with `ubuntu-latest`. This PR makes all workflows run on the same environment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
