### PR TITLE
hotfix: Remove chart 3.20.1 from index

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -3,42 +3,6 @@ entries:
   nri-kube-events:
   - apiVersion: v2
     appVersion: 2.20.0
-    created: "2026-06-10T05:42:22.763782473Z"
-    dependencies:
-    - name: common-library
-      repository: https://helm-charts.newrelic.com
-      version: 2.3.1
-    description: A Helm chart to deploy the New Relic Kube Events router
-    digest: fe7b1ecbc09acc01a274484752422eabb0c20324e2bc2b91fa3e4fe814a4b7d7
-    home: https://docs.newrelic.com/docs/integrations/kubernetes-integration/kubernetes-events/install-kubernetes-events-integration
-    icon: https://newrelic.com/themes/custom/curio/assets/mediakit/NR_logo_Horizontal.svg
-    keywords:
-    - infrastructure
-    - newrelic
-    - monitoring
-    maintainers:
-    - name: danielstokes
-      url: https://github.com/danielstokes
-    - name: dbudziwojskiNR
-      url: https://github.com/dbudziwojskiNR
-    - name: kondracek-nr
-      url: https://github.com/kondracek-nr
-    - name: kpattaswamy
-      url: https://github.com/kpattaswamy
-    - name: Philip-R-Beckwith
-      url: https://github.com/Philip-R-Beckwith
-    - name: TmNguyen12
-      url: https://github.com/TmNguyen12
-    name: nri-kube-events
-    sources:
-    - https://github.com/newrelic/nri-kube-events/
-    - https://github.com/newrelic/nri-kube-events/tree/main/charts/nri-kube-events
-    - https://github.com/newrelic/infrastructure-agent/
-    urls:
-    - https://github.com/newrelic/nri-kube-events/releases/download/nri-kube-events-3.20.1/nri-kube-events-3.20.1.tgz
-    version: 3.20.1
-  - apiVersion: v2
-    appVersion: 2.20.0
     created: "2026-06-08T13:39:53.100302388Z"
     dependencies:
     - name: common-library


### PR DESCRIPTION
## Description
Removes incorrectly released chart from helm repo index.

## Type of change
<!-- Please check the relevant option. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature / enhancement (non-breaking change which adds functionality)
- [ ] Security fix
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!-- Please check applicable options. -->

- [ ] Add changelog entry following the [contributing guide](https://github.com/newrelic/nri-kube-events/blob/main/CONTRIBUTING.md#pull-requests)
- [ ] Documentation has been updated
- [ ] This change requires changes in testing:
  - [ ] unit tests
  - [ ] E2E tests
